### PR TITLE
Display custom badge fields with level icon

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -17,6 +17,14 @@
       align-items: center;
       margin: 0 8px 0 0;
 
+      &.custom-text-badge {
+        font-size: var(--font-down-1);
+      }
+
+      &.level-badge {
+        margin-right: 4px;
+      }
+
       &.badge-type-bronze .fa {
         color: $bronze;
       }

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# name: discourse-post-badges
+# about: Adds custom badge display based on user fields and gamification level
+# version: 0.1
+# authors: ChatGPT
+
+after_initialize do
+  add_to_serializer(:post, :custom_badges) do
+    fields = ["대표 뱃지1", "대표 뱃지2", "대표 뱃지3"]
+    fields.map { |f| object.user&.custom_fields&.[](f) }.compact
+  end
+
+  add_to_serializer(:post, :gamification_level) do
+    if defined?(DiscourseGamification::LevelHelper)
+      DiscourseGamification::LevelHelper.progress_for(object.user_id)
+    end
+  end
+
+  add_to_serializer(:post, :include_custom_badges?) { true }
+  add_to_serializer(:post, :include_gamification_level?) { true }
+end


### PR DESCRIPTION
## Summary
- add plugin-side serializer to expose custom badge fields and gamification level
- render badges from custom user fields
- show gamification level image next to badges
- style new badge classes

## Testing
- `bundle exec rspec` *(fails: command not found)*
- `pnpm exec eslint javascripts/discourse/initializers/initialize-discourse-post-badges.js` *(fails: fetch failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68649119e0ac832cb8631adb8fdf8477