### PR TITLE
Limit post badges to selected custom fields

### DIFF
--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js
@@ -1,19 +1,104 @@
+import { schedule } from "@ember/runloop";
+import { iconHTML } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
+const BADGE_CLASS = [
+  "badge-type-gold",
+  "badge-type-silver",
+  "badge-type-bronze",
+];
+
+const TRUST_LEVEL_BADGE = ["basic", "member", "regular", "leader"];
+
+function buildBadge(badge) {
+  let iconBody;
+
+  if (badge.image) {
+    const img = document.createElement("img");
+    img.setAttribute("src", badge.image);
+    iconBody = img.outerHTML;
+  } else if (badge.icon) {
+    iconBody = iconHTML(badge.icon);
+  }
+
+  if (badge.url) {
+    const link = document.createElement("a");
+    link.setAttribute("href", badge.url);
+    link.innerHTML = iconBody;
+    iconBody = link;
+  }
+
+  const span = document.createElement("span");
+  span.classList.add("poster-icon");
+  span.classList.add(badge.className);
+  if (badge.id >= 1 && badge.id <= 4) {
+    span.classList.add(TRUST_LEVEL_BADGE[badge.id - 1]);
+  }
+  span.setAttribute("title", badge.title);
+  span.appendChild(iconBody);
+  return span;
+}
+
+function prepareRepresentativeBadges(allBadges, names = []) {
+  const lowerNames = names.filter(Boolean).map((n) => n.toLowerCase());
+
+  return allBadges
+    .filter((badge) => lowerNames.includes(badge.name.toLowerCase()))
+    .map((badge) => ({
+      icon: badge.icon?.replace("fa-", ""),
+      image: badge.image_url || badge.image,
+      className: BADGE_CLASS[badge.badge_type_id - 1],
+      name: badge.slug,
+      id: badge.id,
+      badgeGroup: badge.badge_grouping_id,
+      title: badge.description,
+      url: `/badges/${badge.id}/${badge.slug}`,
+    }));
+}
+
+function appendBadges(badges, decorator) {
+  const selector = `[data-post-id="${decorator.attrs.id}"] .poster-icon-container`;
+
+  let trustLevel = "";
+  let highestBadge = 0;
+  const badgesNodes = [];
+  badges.forEach((badge) => {
+    badgesNodes.push(buildBadge(badge));
+    if (badge.badgeGroup === 4 && badge.id > highestBadge) {
+      highestBadge = badge.id;
+      trustLevel = `${TRUST_LEVEL_BADGE[highestBadge - 1]}-highest`;
+    }
+  });
+
+  schedule("afterRender", () => {
+    const postContainer = document.querySelector(selector);
+    if (postContainer) {
+      postContainer.innerHTML = "";
+      trustLevel && postContainer.classList.add(trustLevel);
+      badgesNodes.forEach((badgeNode) => postContainer.appendChild(badgeNode));
+    }
+  });
+}
+
 export default {
-  name: "add-user-level-icon",
+  name: "discourse-post-badges",
 
-  initialize() {
+  initialize(container) {
     withPluginApi("0.8.25", (api) => {
-      api.decorateWidget("user-name:before", (dec) => {
-        const user = dec.attrs.user;
-        // const imageUrl = user?.user_level_image_url; // 실제 이미지 로직은 잠시 비활성화
+      const isMobileView = container.lookup("service:site").mobileView;
+      const location = isMobileView ? "before" : "after";
 
-        // 테스트용 빨간 div 출력
-        return dec.h("div", {
-          style:
-            "width: 16px; height: 16px; background-color: red; margin-right: 4px; display: inline-block; vertical-align: middle;",
-        });
+      api.decorateWidget(`poster-name:${location}`, (decorator) => {
+        const post = decorator.widget.findAncestorModel();
+        if (post?.userBadges) {
+          const preparedBadges = prepareRepresentativeBadges(post.userBadges, [
+            post.representative_badge_1,
+            post.representative_badge_2,
+          ]);
+
+          appendBadges(preparedBadges, decorator);
+          return decorator.h("div.poster-icon-container", {}, []);
+        }
       });
     });
   },

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,10 +3,10 @@
 # version: 0.1
 # authors: 쫑뿌
 
-  after_initialize do
-    %w[대표 배지1 대표 배지2 대표 배지3].each_with_index do |field, idx|
-      add_to_serializer(:post, "representative_badge_#{idx + 1}".to_sym) do
-        object.user&.custom_fields[field]
-      end
+after_initialize do
+  %w[대표 배지1 대표 배지2].each_with_index do |field, idx|
+    add_to_serializer(:post, "representative_badge_#{idx + 1}".to_sym) do
+      object.user&.custom_fields[field]
     end
   end
+end


### PR DESCRIPTION
## Summary
- only serialize the first two representative badges
- restore badge logic to display selected badges next to post author name

## Testing
- `npx prettier` *(fails: Cannot find module '@discourse/lint-configs/prettier')*
- `npx eslint` *(fails: Cannot find package '@discourse/lint-configs')*
- `bundle exec rake` *(fails: Bundler::GemNotFound)*


------
https://chatgpt.com/codex/tasks/task_e_6868d72b3f5c832c8223368a5dc376f3