### PR TITLE
Update to show favorite badges via query

### DIFF
--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js
@@ -91,11 +91,10 @@ export default {
       api.decorateWidget(`poster-name:${location}`, (helper) => {
         const post = helper.getModel();
         if (post?.userBadges) {
-          const preparedBadges = prepareRepresentativeBadges(post.userBadges, [
-            post.representative_badge_1,
-            post.representative_badge_2,
-            post.representative_badge_3,
-          ]);
+          const preparedBadges = prepareRepresentativeBadges(
+            post.userBadges,
+            post.favorite_badges
+          );
 
           appendBadges(preparedBadges, helper);
           return helper.h("div.poster-icon-container", {}, []);

--- a/plugin.rb
+++ b/plugin.rb
@@ -4,9 +4,16 @@
 # authors: 쫑뿌
 
 after_initialize do
-  %w[대표 배지1 대표 배지2 대표 배지3].each_with_index do |field, idx|
-    add_to_serializer(:post, "representative_badge_#{idx + 1}".to_sym) do
-      object.user&.custom_fields[field]
+  add_to_serializer(:post, :favorite_badges) do
+    if (user = object.user)
+      UserBadge
+        .joins(:badge)
+        .where(user_id: user.id, is_favorite: true)
+        .order("user_badges.id")
+        .limit(3)
+        .pluck("badges.name")
+    else
+      []
     end
   end
 end


### PR DESCRIPTION
## Summary
- fetch favorite badges from `user_badges` instead of custom user fields
- render those favorite badges in posts

## Testing
- `bundle exec rake` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_686c5536b514832c9e06841bbe0a7a24