### PR TITLE
Fix favorite badge data mismatch

### DIFF
--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js
@@ -44,8 +44,12 @@ function buildBadge(badge) {
   return span;
 }
 
-function prepareRepresentativeBadges(allBadges, names = []) {
-  const lowerNames = names.filter(Boolean).map((n) => n.toLowerCase());
+function prepareRepresentativeBadges(allBadges, favorites = []) {
+  const lowerNames = favorites
+    .filter(Boolean)
+    .map((item) => (typeof item === "string" ? item : item.name))
+    .filter(Boolean)
+    .map((n) => n.toLowerCase());
 
   return allBadges
     .filter((badge) => lowerNames.includes(badge.name.toLowerCase()))

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,23 +7,12 @@ after_initialize do
   add_to_serializer(:post, :favorite_badges) do
     if (user = object.user)
       UserBadge
-        .includes(badge: :image_upload)
+        .includes(:badge)
         .where(user_id: user.id, is_favorite: true)
         .order("user_badges.id")
         .limit(3)
         .map(&:badge)
-        .map do |badge|
-          {
-            id: badge.id,
-            name: badge.name,
-            slug: badge.slug,
-            icon: badge.icon,
-            image: badge.image_upload&.url,
-            description: badge.description,
-            badge_type_id: badge.badge_type_id,
-            badge_grouping_id: badge.badge_grouping_id
-          }
-        end
+        .map(&:name)
     else
       []
     end


### PR DESCRIPTION
## Summary
- serialize only badge names for each post
- let the JS initializer handle favorite badges delivered as either names or full objects

## Testing
- `bundle exec rspec spec/system/post_badges_spec.rb` *(fails: `bundler: command not found: rspec`)*

------
https://chatgpt.com/codex/tasks/task_e_686cc7109914832c8524fb3c43c4050c