### PR TITLE
Use favorite badges query

### DIFF
--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js
@@ -44,25 +44,18 @@ function buildBadge(badge) {
   return span;
 }
 
-function prepareRepresentativeBadges(allBadges, favorites = []) {
-  const lowerNames = favorites
-    .filter(Boolean)
-    .map((item) => (typeof item === "string" ? item : item.name))
-    .filter(Boolean)
-    .map((n) => n.toLowerCase());
-
-  return allBadges
-    .filter((badge) => lowerNames.includes(badge.name.toLowerCase()))
-    .map((badge) => ({
-      icon: badge.icon?.replace("fa-", ""),
-      image: badge.image, // ← 백엔드에서 image_upload.url 들어오는 값
-      className: BADGE_CLASS[badge.badge_type_id - 1],
-      name: badge.slug,
-      id: badge.id,
-      badgeGroup: badge.badge_grouping_id,
-      title: badge.description,
-      url: `/badges/${badge.id}/${badge.slug}`,
-    }));
+function prepareRepresentativeBadges(favorites = []) {
+  console.log("prepareRepresentativeBadges favorites", favorites);
+  return favorites.map((badge) => ({
+    icon: badge.icon?.replace("fa-", ""),
+    image: badge.image,
+    className: BADGE_CLASS[badge.badge_type_id - 1],
+    name: badge.slug,
+    id: badge.id,
+    badgeGroup: badge.badge_grouping_id,
+    title: badge.description,
+    url: `/badges/${badge.id}/${badge.slug}`,
+  }));
 }
 
 function appendBadges(badges, helper) {
@@ -100,12 +93,10 @@ export default {
 
       api.decorateWidget(`poster-name:${location}`, (helper) => {
         const post = helper.getModel();
-        if (post?.userBadges) {
-          const preparedBadges = prepareRepresentativeBadges(
-            post.userBadges,
-            post.favorite_badges
-          );
-
+        if (post?.favorite_badges?.length) {
+          console.log("favorite_badges from server", post.favorite_badges);
+          const preparedBadges = prepareRepresentativeBadges(post.favorite_badges);
+          console.log("prepared badges", preparedBadges);
           appendBadges(preparedBadges, helper);
           return helper.h("div.poster-icon-container", {}, []);
         }

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,8 +11,19 @@ after_initialize do
         .where(user_id: user.id, is_favorite: true)
         .order("user_badges.id")
         .limit(3)
-        .map(&:badge)
-        .map(&:name)
+        .map do |user_badge|
+          badge = user_badge.badge
+          {
+            id: badge.id,
+            name: badge.name,
+            description: badge.description,
+            image: badge.image_upload&.url,
+            icon: badge.icon,
+            slug: badge.slug,
+            badge_grouping_id: badge.badge_grouping_id,
+            badge_type_id: badge.badge_type_id,
+          }
+        end
     else
       []
     end


### PR DESCRIPTION
## Summary
- query each user's favorite badges instead of relying on a theme setting
- render the favorite badges directly in JS and log them for easier debugging

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686f438c2184832c84412d57db800083